### PR TITLE
Disable rustfmt on the bindings, as it can occasionally cause build breakage

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -137,6 +137,7 @@ fn build(frameworks_path: &str) {
     let bindings = builder
         .trust_clang_mangling(false)
         .derive_default(true)
+        .rustfmt_bindings(false)
         .generate()
         .expect("unable to generate bindings");
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rustaudio/coreaudio-sys/13)
<!-- Reviewable:end -->
