### PR TITLE
Build on MacOS 10.13

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -48,10 +48,7 @@ fn frameworks_path() -> Result<String, std::io::Error> {
             unreachable!();
         };
 
-        let infix = format!(
-            "Platforms/{}.platform/Developer/SDKs/{}.sdk",
-            platform, platform
-        );
+        let infix = format!("SDKs/{}.sdk", platform);
         let suffix = "System/Library/Frameworks";
         let directory = format!("{}/{}/{}", prefix, infix, suffix);
 


### PR DESCRIPTION
Hi there!

I couldn't get this library (0.2.1) to compile on my mac (macOS 10.13.4 High Sierra). This patch fixes that for me. I'm not super familiar with where macOS system libraries are kept, but I know for certain that I was getting the following error when trying to compile:

`error: header '/Library/Developer/CommandLineTools/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreMIDI.frame
work/Headers/CoreMIDI.h' does not exist.`

The proper location on my system is `/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreMIDI.framework/Headers/CoreMIDI.h`.