### PR TITLE
fix: Use a different infix path for when commandline tools is only available

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -48,10 +48,12 @@ fn frameworks_path() -> Result<String, std::io::Error> {
             unreachable!();
         };
 
-        let infix = format!(
-            "Platforms/{}.platform/Developer/SDKs/{}.sdk",
-            platform, platform
-        );
+        let infix = if prefix == "/Library/Developer/CommandLineTools" {
+            format!("SDKs/{}.sdk", platform)
+        } else {
+            format!("Platforms/{}.platform/Developer/SDKs/{}.sdk", platform, platform)
+        };
+
         let suffix = "System/Library/Frameworks";
         let directory = format!("{}/{}/{}", prefix, infix, suffix);
 


### PR DESCRIPTION
@mitchmindtree This should fix the build for when command line tools is available only.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rustaudio/coreaudio-sys/15)
<!-- Reviewable:end -->
