### PR TITLE
Updated `bindgen` version.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/RustAudio/coreaudio-sys.git"
 build = "build.rs"
 
 [build-dependencies]
-bindgen = "0.32"
+bindgen = "0.42"
 
 [features]
 default = ["audio_toolbox", "audio_unit", "core_audio", "open_al", "core_midi"]

--- a/build.rs
+++ b/build.rs
@@ -51,7 +51,10 @@ fn frameworks_path() -> Result<String, std::io::Error> {
         let infix = if prefix == "/Library/Developer/CommandLineTools" {
             format!("SDKs/{}.sdk", platform)
         } else {
-            format!("Platforms/{}.platform/Developer/SDKs/{}.sdk", platform, platform)
+            format!(
+                "Platforms/{}.platform/Developer/SDKs/{}.sdk",
+                platform, platform
+            )
         };
 
         let suffix = "System/Library/Frameworks";
@@ -131,8 +134,8 @@ fn build(frameworks_path: &str) {
 
     // Link to all frameworks.
     for relative_path in frameworks {
-        let absolute_path = format!("{}/{}", frameworks_path, relative_path);
-        builder = builder.link_framework(absolute_path);
+        let link_instruction = format!("#[link = \"{}/{}\"]", frameworks_path, relative_path);
+        builder = builder.raw_line(link_instruction);
     }
 
     // Generate the bindings.


### PR DESCRIPTION
Just some maintenance -- trying to bump dependencies. I haven't got a Mac to test this on so would need someone to test this.

The code change is based on:

* https://github.com/rust-lang-nursery/rust-bindgen/issues/104 (https://github.com/rust-lang-nursery/rust-bindgen/commit/8e3e585b6efc6771cac8a9fa6ef9f9310c3d0f08)
* https://github.com/rust-lang-nursery/rust-bindgen/issues/1358

Would like to update `coreaudio-rs` as well after this