### PR TITLE
Update crate for Rust 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 homepage = "https://github.com/RustAudio/coreaudio-sys"
 repository = "https://github.com/RustAudio/coreaudio-sys.git"
 build = "build.rs"
+edition = "2018"
 
 [build-dependencies]
 bindgen = "0.42"

--- a/build.rs
+++ b/build.rs
@@ -10,7 +10,7 @@ fn osx_version() -> Result<String, std::io::Error> {
         .output()?
         .stdout;
     let version_str = std::str::from_utf8(&output).expect("invalid output from `defaults`");
-    let version = version_str.trim_right();
+    let version = version_str.trim_end();
 
     Ok(version.to_owned())
 }
@@ -38,7 +38,7 @@ fn frameworks_path() -> Result<String, std::io::Error> {
 
         let output = Command::new("xcode-select").arg("-p").output()?.stdout;
         let prefix_str = std::str::from_utf8(&output).expect("invalid output from `xcode-select`");
-        let prefix = prefix_str.trim_right();
+        let prefix = prefix_str.trim_end();
 
         let platform = if cfg!(target_os = "macos") {
             "MacOSX"


### PR DESCRIPTION
Update crate for Rust 2018 using 'cargo fix --edition'