### PR TITLE
Add a github action to check cross-compilation from Linux

### DIFF
--- a/.github/workflows/coreaudio-sys.yml
+++ b/.github/workflows/coreaudio-sys.yml
@@ -37,6 +37,28 @@ jobs:
     - name: cargo doc - all features
       run: cargo doc --all-features --verbose
 
+  # Check that cross-compilation from linux is working.
+  # TODO: This is adapted from old travis file, should probably also:
+  # - Check more feature permutations.
+  # - Use more recent SDK? Looks like 10.13 is used atm.
+  # - Check iOS target?
+  linux-cross-compile:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install stable
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        override: true
+    - name: Add apple target
+      run: rustup target add x86_64-apple-darwin
+    - name: Download SDK
+      run: curl -sL https://github.com/phracker/MacOSX-SDKs/releases/download/10.13/MacOSX10.13.sdk.tar.xz | tar -Jxf -; export COREAUDIO_SDK_PATH="$PWD/MacOSX10.13.sdk"
+    - name: Cargo build
+      run: cargo build --verbose --target=x86_64-apple-darwin
+
   # Publish a new version when pushing to master.
   # Will succeed if the version has been updated, otherwise silently fails.
   cargo-publish:


### PR DESCRIPTION
This is a port of the old travis-ci cross-compile check, which currently does not seem to be working.

Downloading the SDK works fine, but initially building produces a "missing libclang.so" error.

On NixOS I threw together a small nix shell to get fix the clang error by setting `LIBCLANG_PATH` and automating the SDK install, however I ran into another error where bindgen seems unable to find the "AudioToolbox/AudioToolbox.h" for some reason. I don't have time to dive deeper into this atm, but thought I'd post my efforts so far in case someone finds them useful.


## Nix exprs

Here are my nix expressions in case anyone using nix happens to be digging into this. Using these are not necessary to solve the CI build issues though.

**macosx-sdk.nix** - _Simple package that downloads and "installs" the SDK_
```nix
{ stdenv, fetchurl, clang }:
stdenv.mkDerivation {
  name = "macosx-sdk";
  src = fetchurl {
    url = https://github.com/phracker/MacOSX-SDKs/releases/download/10.13/MacOSX10.13.sdk.tar.xz;
    sha256 = "1az86x4lk6l3kxbxa1ppsahnwgpka1a6vpavazrv91wjms4n92xj";
  };
  dontConfigure = true;
  dontBuild = true;
  installPhase = ''
    mkdir -p $out
    cp -r ./ $out/MacOSX10.13.sdk
  '';
}
```

**coreaudio-dev.nix** - _Simple shell that includes macosx-sdk, libclang and sets the environment variables_
```nix
with import <nixpkgs> {};
let
  macosx-sdk = callPackage ./macosx-sdk.nix {};
in
  stdenv.mkDerivation {
    name = "coreaudio-dev";
    buildInputs = [
      llvmPackages.libclang
      macosx-sdk
    ];
    COREAUDIO_SDK_PATH = "${macosx-sdk}/MacOSX10.13.sdk";
    LIBCLANG_PATH = "${llvmPackages.libclang}/lib";
  }
```