### PR TITLE
Add docs.rs badge. Publish 0.2.5.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coreaudio-sys"
-version = "0.2.4"
+version = "0.2.5"
 authors = ["Mitchell Nordine <mitchell.nordine@gmail.com>"]
 description = "Bindings for Apple's CoreAudio frameworks generated via rust-bindgen"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# coreaudio-sys [![Actions Status](https://github.com/rustaudio/coreaudio-sys/workflows/coreaudio-sys/badge.svg)](https://github.com/rustaudio/coreaudio-sys/actions) [![Crates.io](https://img.shields.io/crates/v/coreaudio-sys.svg)](https://crates.io/crates/coreaudio-sys) [![Crates.io](https://img.shields.io/crates/l/coreaudio-sys.svg)](https://github.com/RustAudio/coreaudio-sys/blob/master/LICENSE)
+# coreaudio-sys [![Actions Status](https://github.com/rustaudio/coreaudio-sys/workflows/coreaudio-sys/badge.svg)](https://github.com/rustaudio/coreaudio-sys/actions) [![Crates.io](https://img.shields.io/crates/v/coreaudio-sys.svg)](https://crates.io/crates/coreaudio-sys) [![Crates.io](https://img.shields.io/crates/l/coreaudio-sys.svg)](https://github.com/RustAudio/coreaudio-sys/blob/master/LICENSE) [![docs.rs](https://docs.rs/coreaudio-sys/badge.svg)](https://docs.rs/coreaudio-sys/)
 
 Raw bindings to Apple's Core Audio API for macos and iOS generated using [rust-bindgen](https://github.com/rust-lang-nursery/rust-bindgen). [coreaudio-rs](https://github.com/RustAudio/coreaudio-rs) is an attempt at offering a higher level API around this crate.
 


### PR DESCRIPTION
This is a tiny release to:

- Fix docs generated and presented on docs.rs.
- Fixes builds using --no-default-features.