### PR TITLE
Update Bindgen for Compatibility with macOS 11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/RustAudio/coreaudio-sys.git"
 build = "build.rs"
 
 [build-dependencies.bindgen]
-version = "0.53"
+version = "0.56"
 default-features = false
 features = ["runtime"]
 


### PR DESCRIPTION
The version of Rust Bindgen prior to 0.56 would not compile on macOS 11. Bumping the dependency version of Bindgen to fix this bug in CoreAudio-Sys.