### PR TITLE
Fix AudioUnit linking

### DIFF
--- a/.github/workflows/coreaudio-sys.yml
+++ b/.github/workflows/coreaudio-sys.yml
@@ -4,6 +4,9 @@ jobs:
   # Run cargo test with default, no and all features.
   macos-test:
     runs-on: macOS-latest
+    strategy:
+      matrix:
+        toolchain: [stable, nightly]
     steps:
     - uses: actions/checkout@v2
     - name: Install llvm and clang
@@ -12,7 +15,7 @@ jobs:
       uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: stable
+        toolchain: ${{ matrix.toolchain }}
         override: true
     - name: cargo test
       run: cargo test --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coreaudio-sys"
-version = "0.2.8"
+version = "0.2.9"
 authors = ["Mitchell Nordine <mitchell.nordine@gmail.com>"]
 description = "Bindings for Apple's CoreAudio frameworks generated via rust-bindgen"
 license = "MIT"

--- a/build.rs
+++ b/build.rs
@@ -47,16 +47,16 @@ fn build(sdk_path: Option<&str>, target: &str) {
 
     let mut headers: Vec<&'static str> = vec![];
 
+    #[cfg(feature = "audio_unit")]
+    {
+        println!("cargo:rustc-link-lib=framework=AudioUnit");
+        headers.push("AudioUnit/AudioUnit.h");
+    }
+
     #[cfg(feature = "audio_toolbox")]
     {
         println!("cargo:rustc-link-lib=framework=AudioToolbox");
         headers.push("AudioToolbox/AudioToolbox.h");
-    }
-
-    #[cfg(feature = "audio_unit")]
-    {
-        println!("cargo:rustc-link-lib=framework=AudioToolbox");
-        headers.push("AudioUnit/AudioUnit.h");
     }
 
     #[cfg(feature = "core_audio")]

--- a/build.rs
+++ b/build.rs
@@ -49,7 +49,23 @@ fn build(sdk_path: Option<&str>, target: &str) {
 
     #[cfg(feature = "audio_unit")]
     {
-        println!("cargo:rustc-link-lib=framework=AudioUnit");
+        // Since iOS 10.0 and macOS 10.12, all the functionality in AudioUnit
+        // moved to AudioToolbox, and the AudioUnit headers have been simple
+        // wrappers ever since.
+        if target.contains("apple-ios") {
+            // On iOS, the AudioUnit framework does not have (and never had) an
+            // actual dylib to link to, it is just a few header files.
+            // The AudioToolbox framework contains the symbols instead.
+            println!("cargo:rustc-link-lib=framework=AudioToolbox");
+        } else {
+            // On macOS, the symbols are present in the AudioToolbox framework,
+            // but only on macOS 10.12 and above.
+            //
+            // However, unlike on iOS, the AudioUnit framework on macOS
+            // contains a dylib with the desired symbols, that we can link to
+            // (in later versions just re-exports from AudioToolbox).
+            println!("cargo:rustc-link-lib=framework=AudioUnit");
+        }
         headers.push("AudioUnit/AudioUnit.h");
     }
 


### PR DESCRIPTION
Replaces / builds upon https://github.com/RustAudio/coreaudio-sys/pull/49, see that discussion first.

In particular, I've reverted the linking on iOS, since there, the AudioUnit framework is not (and newer were) linkable, instead one should link to AudioToolbox.

[Kinda weak source](https://stackoverflow.com/a/14120936), but verified by looking at simulator runtimes (this is what I could find) for version 9.3 and 10.3, on both of these AudioUnit does not contain a dylib (unlike most other frameworks). Also, in all SDK versions it's missing an AudioUnit.tbd file (which describes e.g. which symbols the library exposes).

<sub>A quick tip: You can gain a lot of knowledge from looking at the headers from previous SDKs e.g. [these for macOS](https://github.com/phracker/MacOSX-SDKs) or [these for iOS](https://github.com/xybp888/iOS-SDKs) (both links are non-official).</sub>