### PR TITLE
WIP objc/block support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,13 @@ repository = "https://github.com/RustAudio/coreaudio-sys.git"
 build = "build.rs"
 
 [build-dependencies.bindgen]
-version = "0.56"
+version = "0.59.2"
 default-features = false
 features = ["runtime"]
+
+[dependencies]
+objc = { version = "0.2.7", optional = true }
+block = { version = "0.1.6", optional = true }
 
 [features]
 default = ["audio_toolbox", "audio_unit", "core_audio", "open_al", "core_midi"]


### PR DESCRIPTION
Attempting a fix for https://github.com/RustAudio/coreaudio-sys/issues/52 but running into compile errors. Also note that the generated code goes from 50k lines to like 270k lines and in debug goes from 18s to 88s.

```$ cargo build --features objc
error[E0587]: type has conflicting packed and align representation hints
      --> /Users/mikeh/repos/coreaudio-sys/target/debug/build/coreaudio-sys-f703e57cba00ad27/out/coreaudio.rs:185578:1
       |
185578 | / pub struct FndrOpaqueInfo {
185579 | |     pub opaque: [i8; 16usize],
185580 | | }
       | |_^

error[E0588]: packed type cannot transitively contain a `#[repr(align)]` type
      --> /Users/mikeh/repos/coreaudio-sys/target/debug/build/coreaudio-sys-f703e57cba00ad27/out/coreaudio.rs:186145:1
       |
186145 | / pub struct HFSCatalogFolder {
186146 | |     pub recordType: i16,
186147 | |     pub flags: u_int16_t,
186148 | |     pub valence: u_int16_t,
...      |
186155 | |     pub reserved: [u_int32_t; 4usize],
186156 | | }
       | |_^
       |
note: `FndrOpaqueInfo` has a `#[repr(align)]` attribute
      --> /Users/mikeh/repos/coreaudio-sys/target/debug/build/coreaudio-sys-f703e57cba00ad27/out/coreaudio.rs:185578:1
       |
185578 | / pub struct FndrOpaqueInfo {
185579 | |     pub opaque: [i8; 16usize],
185580 | | }
       | |_^

error[E0588]: packed type cannot transitively contain a `#[repr(align)]` type
      --> /Users/mikeh/repos/coreaudio-sys/target/debug/build/coreaudio-sys-f703e57cba00ad27/out/coreaudio.rs:186272:1
       |
186272 | / pub struct HFSPlusCatalogFolder {
186273 | |     pub recordType: i16,
186274 | |     pub flags: u_int16_t,
186275 | |     pub valence: u_int32_t,
...      |
186286 | |     pub folderCount: u_int32_t,
186287 | | }
       | |_^
       |
note: `FndrOpaqueInfo` has a `#[repr(align)]` attribute
      --> /Users/mikeh/repos/coreaudio-sys/target/debug/build/coreaudio-sys-f703e57cba00ad27/out/coreaudio.rs:185578:1
       |
185578 | / pub struct FndrOpaqueInfo {
185579 | |     pub opaque: [i8; 16usize],
185580 | | }
       | |_^

error[E0588]: packed type cannot transitively contain a `#[repr(align)]` type
      --> /Users/mikeh/repos/coreaudio-sys/target/debug/build/coreaudio-sys-f703e57cba00ad27/out/coreaudio.rs:186460:1
       |
186460 | / pub struct HFSCatalogFile {
186461 | |     pub recordType: i16,
186462 | |     pub flags: u_int8_t,
186463 | |     pub fileType: i8,
...      |
186479 | |     pub reserved: u_int32_t,
186480 | | }
       | |_^
       |
note: `FndrOpaqueInfo` has a `#[repr(align)]` attribute
      --> /Users/mikeh/repos/coreaudio-sys/target/debug/build/coreaudio-sys-f703e57cba00ad27/out/coreaudio.rs:185578:1
       |
185578 | / pub struct FndrOpaqueInfo {
185579 | |     pub opaque: [i8; 16usize],
185580 | | }
       | |_^

error[E0588]: packed type cannot transitively contain a `#[repr(align)]` type
      --> /Users/mikeh/repos/coreaudio-sys/target/debug/build/coreaudio-sys-f703e57cba00ad27/out/coreaudio.rs:186686:1
       |
186686 | / pub struct HFSPlusCatalogFile {
186687 | |     pub recordType: i16,
186688 | |     pub flags: u_int16_t,
186689 | |     pub reserved1: u_int32_t,
...      |
186702 | |     pub resourceFork: HFSPlusForkData,
186703 | | }
       | |_^
       |
note: `FndrOpaqueInfo` has a `#[repr(align)]` attribute
      --> /Users/mikeh/repos/coreaudio-sys/target/debug/build/coreaudio-sys-f703e57cba00ad27/out/coreaudio.rs:185578:1
       |
185578 | / pub struct FndrOpaqueInfo {
185579 | |     pub opaque: [i8; 16usize],
185580 | | }
       | |_^

error: aborting due to 5 previous errors

Some errors have detailed explanations: E0587, E0588.
For more information about an error, try `rustc --explain E0587`.
error: could not compile `coreaudio-sys`

```