### PR TITLE
Bump version to 0.2.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coreaudio-sys"
-version = "0.2.10"
+version = "0.2.11"
 authors = ["Mitchell Nordine <mitchell.nordine@gmail.com>"]
 description = "Bindings for Apple's CoreAudio frameworks generated via rust-bindgen"
 license = "MIT"


### PR DESCRIPTION
This is to release #65. I figure if Emilio authored it (rather than dependabot), it should be released. I tested this with the bevy audio stuff. I don't think there's a breaking change.