### PR TITLE
Minor version bump to 0.2.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coreaudio-sys"
-version = "0.2.11"
+version = "0.2.12"
 authors = ["Mitchell Nordine <mitchell.nordine@gmail.com>"]
 description = "Bindings for Apple's CoreAudio frameworks generated via rust-bindgen"
 license = "MIT"


### PR DESCRIPTION
I've checked if this is a breaking change using https://github.com/obi1kenobi/cargo-semver-checks which shows no breaking changes.

Closes #75.