### PR TITLE
Add a feature for MacOS' IOKit/audio/IOAudioTypes.h

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coreaudio-sys"
-version = "0.2.13"
+version = "0.2.14"
 authors = ["Mitchell Nordine <mitchell.nordine@gmail.com>"]
 description = "Bindings for Apple's CoreAudio frameworks generated via rust-bindgen"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ default = ["audio_toolbox", "audio_unit", "core_audio", "open_al", "core_midi"]
 audio_toolbox = []
 audio_unit = []
 core_audio = []
+io_kit_audio = []
 open_al = []
 core_midi = []
 

--- a/build.rs
+++ b/build.rs
@@ -86,6 +86,13 @@ fn build(sdk_path: Option<&str>, target: &str) {
         }
     }
 
+    #[cfg(feature = "io_kit_audio")]
+    {
+        assert!(target.contains("apple-darwin"));
+        println!("cargo:rustc-link-lib=framework=IOKit");
+        headers.push("IOKit/audio/IOAudioTypes.h");
+    }
+
     #[cfg(feature = "open_al")]
     {
         println!("cargo:rustc-link-lib=framework=OpenAL");


### PR DESCRIPTION
When querying an AudioStream for its terminal type (kAudioStreamPropertyTerminalType) it will often return a value defined in IOAudioTypes.h (the ranges [INPUT_UNDEFINED, INPUT_MODEM_AUDIO] and [OUTPUT_UNDEFINED, OUTPUT_LOW_FREQUENCY_EFFECTS_SPEAKER]).

This commit adds a feature io_kit_audio that will generate rust bindings for IOAudioTypes.h, so these enum values can be used in rust directly.