### PR TITLE
Support visionOS, watchOS, and tvOS

### DIFF
--- a/.github/workflows/coreaudio-sys.yml
+++ b/.github/workflows/coreaudio-sys.yml
@@ -47,6 +47,36 @@ jobs:
     - name: Build for iOS target ${{matrix.target}}
       run: cargo build --verbose --target=${{matrix.target}}
 
+  apple-tier-3-check:
+    runs-on: macOS-14
+    strategy:
+      matrix:
+        target: [
+          aarch64-apple-visionos,
+          aarch64-apple-visionos-sim,
+          aarch64-apple-watchos,
+          arm64_32-apple-watchos,
+          armv7k-apple-watchos,
+          aarch64-apple-watchos-sim,
+          x86_64-apple-watchos-sim,
+          aarch64-apple-tvos,
+          aarch64-apple-tvos-sim,
+          x86_64-apple-tvos-sim,
+        ]
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: nightly
+        components: rust-src
+
+    - name: Install Xcode Command Line Tools
+      run: sudo xcode-select --switch /Applications/Xcode_15.4.app/Contents/Developer
+
+    - name: Build for visionOS target ${{matrix.target}}
+      run: cargo +nightly build -Z build-std --target=${{matrix.target}}
+
   # Build the docs with all features to make sure docs.rs will work.
   macos-docs:
     runs-on: macOS-latest

--- a/.github/workflows/coreaudio-sys.yml
+++ b/.github/workflows/coreaudio-sys.yml
@@ -61,7 +61,7 @@ jobs:
           x86_64-apple-watchos-sim,
           aarch64-apple-tvos,
           aarch64-apple-tvos-sim,
-          x86_64-apple-tvos-sim,
+          x86_64-apple-tvos,
         ]
     steps:
     - uses: actions/checkout@v4

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg(any(target_os = "macos", target_os = "ios"))]
+#![cfg(target_vendor = "apple")]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]


### PR DESCRIPTION
This work piggy backs off the work in #102.

Things are a bit rough. Based on my exploration of SDK's (that I have on my box), `OpenAL` is on macOS, tvOS and iOS but not watchOS or visionOS. Other than `OpenAL`, it seems that `visionOS`, `watchOS` and `tvOS` all act like `iOS`.

CC @madsmtm the `visionOS` clang target here I think is relevant to your interests.