### PR TITLE
Bump version to 0.2.16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coreaudio-sys"
-version = "0.2.15"
+version = "0.2.16"
 authors = ["Mitchell Nordine <mitchell.nordine@gmail.com>"]
 description = "Bindings for Apple's CoreAudio frameworks generated via rust-bindgen"
 license = "MIT"


### PR DESCRIPTION
[Request from a dependabot PR on bindgen](https://github.com/RustAudio/coreaudio-sys/pull/107#issuecomment-2343528643).

Someday I'll add a CHANGELOG to this repo but the changes are [from db0f487...e435272](https://github.com/RustAudio/coreaudio-sys/compare/db0f487...e435272?expand=1).

@torokati44 mind giving me a review/approval? I don't actually need it to merge but like to exercise good practices.