### PR TITLE
remove target override for bindgen because it isn't necessary

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -120,19 +120,7 @@ fn build(sdk_path: Option<&str>, target: &str) {
     // Begin building the bindgen params.
     let mut builder = bindgen::Builder::default();
 
-    // See https://github.com/rust-lang/rust-bindgen/issues/1211
-    // Technically according to the llvm mailing list, the argument to clang here should be
-    // -arch arm64 but it looks cleaner to just change the target.
-    let target = if target == "aarch64-apple-ios" {
-        "arm64-apple-ios"
-    } else if target == "aarch64-apple-darwin" {
-        "arm64-apple-darwin"
-    } else {
-        target
-    };
     builder = builder.size_t_is_usize(true);
-
-    builder = builder.clang_args(&[&format!("--target={}", target)]);
 
     if let Some(sdk_path) = sdk_path {
         builder = builder.clang_args(&["-isysroot", sdk_path]);


### PR DESCRIPTION
This fixes an issue where `aarch64-apple-ios-sim` won't build with the error:

    unable to generate bindings: ClangDiagnostic("error: version 'sim' in target triple 'aarch64-apple-ios-sim' is invalid\n")

I have a [fix for bindgen](https://github.com/rust-lang/rust-bindgen/pull/3182), but the workaround in build.rs makes this ineffective.