### PR TITLE
Remap iOS simulator target names to fix the build for the simulator

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -14,6 +14,7 @@ fn sdk_path(target: &str) -> Result<String, std::io::Error> {
     } else if target == "x86_64-apple-ios"
         || target == "i386-apple-ios"
         || target == "aarch64-apple-ios-sim"
+        || target == "x86_64-apple-ios-sim"
     {
         "iphonesimulator"
     } else if target == "aarch64-apple-ios"
@@ -127,6 +128,10 @@ fn build(sdk_path: Option<&str>, target: &str) {
         "arm64-apple-ios"
     } else if target == "aarch64-apple-darwin" {
         "arm64-apple-darwin"
+    } else if target == "aarch64-apple-ios-sim" {
+        "arm64-apple-ios-simulator"
+    } else if target == "x86_64-apple-ios-sim" {
+        "x86_64-apple-ios-simulator"
     } else {
         target
     };


### PR DESCRIPTION
This adds additional logic to the `build.rs` script which handles the mismatch between the `-sim` and `-simulator` suffixes — Rust uses the former, and Clang (at least, `Apple clang version 17.0.0 (clang-1700.0.13.3) Target: arm64-apple-darwin24.3.0`) expects the latter.

This patch is motivated by a need to fix the build of [`cpal`](https://github.com/rustaudio/cpal) for the iOS simulator — at present, it fails (at least on my machine) due to this error:

```
error: failed to run custom build command for `coreaudio-sys v0.2.16`

Caused by:
  process didn't exit successfully: `/target/release/build/coreaudio-sys-a853612bd3562b3f/build-script-build` (exit status: 101)
  --- stdout
  cargo:rerun-if-env-changed=COREAUDIO_SDK_PATH
  cargo:rustc-link-lib=framework=AudioToolbox
  cargo:rustc-link-lib=framework=AudioToolbox
  cargo:rustc-link-lib=framework=CoreAudio
  cargo:rerun-if-env-changed=BINDGEN_EXTRA_CLANG_ARGS

  --- stderr

  thread 'main' panicked at /.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/coreaudio-sys-0.2.16/build.rs:162:39:
  unable to generate bindings: ClangDiagnostic("error: version 'sim' in target triple 'aarch64-apple-ios-sim' is invalid\n")
```

I can confirm that with a workspace patch pointed at this fork, `cpal` is able to build successfully for iOS simulator.