### PR TITLE
Fix name of the dispatch_queue_create_with_target

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -145,7 +145,7 @@ fn build(sdk_path: Option<&str>, target: &str) {
     builder = builder.header_contents("coreaudio.h", &meta_header.concat());
 
     // Generate the bindings.
-    builder = builder.trust_clang_mangling(false).derive_default(true);
+    builder = builder.trust_clang_mangling(true).derive_default(true);
 
     let bindings = builder.generate().expect("unable to generate bindings");
 


### PR DESCRIPTION
`dispatch_queue_create_with_target` is defined with `DISPATCH_ALIAS_V2` macro that adds a `_$V2` to the symbol name. However when `trust_clang_mangling(false)` is configured for the builder, bindgen fails to recognize that.

Diff between generated files:

    diff --git a/tmp/old.rs b/tmp/new.rs
    index a07b6c0..207b79b 100644
    --- a/tmp/old.rs
    +++ b/tmp/new.rs
    @@ -7256,6 +7256,7 @@ unsafe extern "C" {
         pub fn rand_r(arg1: *mut ::std::os::raw::c_uint) -> ::std::os::raw::c_int;
     }
     unsafe extern "C" {
    +    #[link_name = "\u{1}_realpath$DARWIN_EXTSN"]
         pub fn realpath(
             arg1: *const ::std::os::raw::c_char,
             arg2: *mut ::std::os::raw::c_char,
    @@ -14340,6 +14341,7 @@ unsafe extern "C" {
         ) -> dispatch_queue_attr_t;
     }
     unsafe extern "C" {
    +    #[link_name = "\u{1}_dispatch_queue_create_with_target$V2"]
         pub fn dispatch_queue_create_with_target(
             label: *const ::std::os::raw::c_char,
             attr: dispatch_queue_attr_t,
    @@ -14427,12 +14429,14 @@ unsafe extern "C" {
         -> *mut ::std::os::raw::c_void;
     }
     unsafe extern "C" {
    +    #[link_name = "\u{1}_dispatch_assert_queue$V2"]
         pub fn dispatch_assert_queue(queue: dispatch_queue_t);
     }
     unsafe extern "C" {
         pub fn dispatch_assert_queue_barrier(queue: dispatch_queue_t);
     }
     unsafe extern "C" {
    +    #[link_name = "\u{1}_dispatch_assert_queue_not$V2"]
         pub fn dispatch_assert_queue_not(queue: dispatch_queue_t);
     }
     unsafe extern "C" {